### PR TITLE
Simpler log to debugger

### DIFF
--- a/Logger/Logger.vcxproj
+++ b/Logger/Logger.vcxproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <ClCompile Include="src\Logger.cpp" />
     <ClCompile Include="src\log_console_sink.cpp" />
+    <ClCompile Include="src\log_debugger_sink.cpp" />
     <ClCompile Include="src\log_file_sink.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -63,6 +64,7 @@
     <ClInclude Include="include\Logger\Logger_api.h" />
     <ClInclude Include="include\Logger\Logger_service.hpp" />
     <ClInclude Include="include\Logger\log_console_sink.hpp" />
+    <ClInclude Include="include\Logger\log_debugger_sink.hpp" />
     <ClInclude Include="include\Logger\log_file_sink.hpp" />
     <ClInclude Include="include\Logger\log_level.hpp" />
     <ClInclude Include="include\Logger\log_sink.hpp" />

--- a/Logger/Logger.vcxproj.filters
+++ b/Logger/Logger.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="include\Logger\log_level.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Logger\log_debugger_sink.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Logger.cpp">
@@ -65,6 +68,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\log_file_sink.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\log_debugger_sink.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Logger/include/Logger/log_debugger_sink.hpp
+++ b/Logger/include/Logger/log_debugger_sink.hpp
@@ -27,18 +27,21 @@
 
 #pragma once
 
+//Windows only
+#if _WIN32
+
 #include "log_sink.hpp"
 #include "Logger_api.h"
 
 namespace logger
 {
-
 ///	\brief Created to do Logging to console
-class log_console_sink final: public log_sink
+class log_debugger_sink final: public log_sink
 {
 public:
-	Logger_API log_console_sink();
+	Logger_API log_debugger_sink();
 	void output(const log_data& p_logData) final;
 };
+} //namespace logger
 
-} // namespace logger
+#endif // _WIN32

--- a/Logger/include/Logger/log_file_sink.hpp
+++ b/Logger/include/Logger/log_file_sink.hpp
@@ -33,7 +33,6 @@
 #include "log_sink.hpp"
 #include "Logger_api.h"
 
-
 namespace logger
 {
 ///	\brief Created to do Logging to file
@@ -61,4 +60,4 @@ private:
 	std::basic_ofstream<char8_t> m_output; //!< Output file
 };
 
-}	// namespace simLog
+}	// namespace logger

--- a/Logger/src/Logger.cpp
+++ b/Logger/src/Logger.cpp
@@ -36,14 +36,6 @@
 #include <CoreLib/Core_String.hpp>
 #include <CoreLib/Core_Thread.hpp>
 
-#if defined(_DEBUG) && defined(_WIN32)
-#	include <Windows.h>
-#	include <WinBase.h>
-#	define __LOG_HAS_DEBUGGER
-#endif	// _WIN32
-
-
-
 //Right now we are enforcing validity by having buffer larger than what we would theorethically need
 static constexpr uintptr_t g_DateTimeThreadMessageSize = sizeof("[00000/000/000-000:000:000.00000|0000000000]") - 1;
 static inline bool formatDateTimeThreadValid(const core::DateTime&)
@@ -158,21 +150,6 @@ static size_t FormatLogLevel(Level p_level,  std::span<char8_t, 9> p_out)
 	return 9;
 }
 
-#ifdef __LOG_HAS_DEBUGGER
-static void output2debugger(
-	core::os_string_view p_file,
-	std::u8string_view p_line,
-	std::u8string_view p_dateTimeThread,
-	std::u8string_view p_category,
-	std::u8string_view p_message)
-{
-	std::basic_stringstream<char16_t> t_stream;
-	t_stream << reinterpret_cast<std::u16string_view&>(p_file) << u'(' << core::ANSI_to_UTF16(p_line) << u"): "
-		<< core::ANSI_to_UTF16(p_dateTimeThread) << u' ' << core::ANSI_to_UTF16(p_category)
-		<< core::ANSI_to_UTF16(p_message) << u'\n';
-	OutputDebugStringW(reinterpret_cast<const wchar_t*>(t_stream.str().c_str()));
-}
-#endif
 
 //======== ======== ======== ======== Class: LoggerHelper ======== ======== ======== ========
 
@@ -213,15 +190,6 @@ void LoggerHelper::log(Level p_level, core::os_string_view p_file, uint32_t p_li
 	{
 		sink->output(log_data);
 	}
-
-#ifdef __LOG_HAS_DEBUGGER
-	output2debugger(
-		p_file,
-		std::u8string_view(line.data(), line_size),
-		std::u8string_view(dateTimeThread.data(), dateTimeThread_size),
-		std::u8string_view(level.data(), level_size),
-		p_message);
-#endif
 }
 
 void LoggerHelper::add_sink(log_sink& p_sink)

--- a/Logger/src/log_debugger_sink.cpp
+++ b/Logger/src/log_debugger_sink.cpp
@@ -25,20 +25,31 @@
 ///		SOFTWARE.
 //======== ======== ======== ======== ======== ======== ======== ========
 
-#pragma once
+#include "Logger/log_debugger_sink.hpp"
 
-#include "log_sink.hpp"
-#include "Logger_api.h"
+#if _WIN32
+
+#include <Windows.h>
+#include <WinBase.h>
+
+#include <sstream>
+#include <string_view>
 
 namespace logger
 {
 
-///	\brief Created to do Logging to console
-class log_console_sink final: public log_sink
-{
-public:
-	Logger_API log_console_sink();
-	void output(const log_data& p_logData) final;
-};
+log_debugger_sink::log_debugger_sink() = default;
 
-} // namespace logger
+void log_debugger_sink::output(const log_data& p_logData)
+{
+	std::basic_stringstream<char16_t> t_stream;
+	t_stream << reinterpret_cast<const std::u16string_view&>(p_logData.m_file) << u'('
+		<< core::ANSI_to_UTF16(p_logData.m_line) << u"): "
+		<< core::ANSI_to_UTF16(p_logData.m_dateTimeThread)
+		<< u' ' << core::ANSI_to_UTF16(p_logData.m_level)
+		<< core::ANSI_to_UTF16(p_logData.m_message) << u'\n';
+	OutputDebugStringW(reinterpret_cast<const wchar_t*>(t_stream.str().c_str()));
+}
+
+} //namespace logger
+#endif // _WIN32

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ The following sinks are provided with this library:
 
 The user can create their own custom sink by inheriting from `logger::log_sink` defined in header `log_sink.hpp`. Note that by convention, the user need not specify a new line at the end of a message (implicit), and thus one will not exist at the end of the message. The implementer of the sink should honor this agreement by adding any extra new line at the end of the stream (if applicable).
 
-### Windows Debug build only
-On a windows debug build, this library will by default also send the logs to the debugger console (for example Visual Studio console) without the need to register a special sink.
+### Windows only
+On a windows only, this library provides a sink that can send the logs to the debugger console (for example Visual Studio console).
 In Visual Studio, this supports the functionality to be able to jump to the referenced file and line when double clicking on the logged message.
 
 ## Thread safety


### PR DESCRIPTION
deprecated logging to the debugger by default, added it as an optional sink, such that it could also be used to log to console in release